### PR TITLE
Remove restriction of 999 results in tables and update use of top query param closes #49

### DIFF
--- a/azuread/table_azuread_application.go
+++ b/azuread/table_azuread_application.go
@@ -77,10 +77,7 @@ func listAdApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	client := msgraph.NewApplicationsClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
+	input := odata.Query{}
 
 	qualsColumnMap := []QualsColumn{
 		{"app_id", "string", "appId"},
@@ -91,13 +88,6 @@ func listAdApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	filter := buildCommaonQueryFilter(qualsColumnMap, d.Quals)
 	if len(filter) > 0 {
 		input.Filter = strings.Join(filter, " and ")
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
 	}
 
 	applications, _, err := client.List(ctx, input)

--- a/azuread/table_azuread_application.go
+++ b/azuread/table_azuread_application.go
@@ -79,6 +79,15 @@ func listAdApplications(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 
 	input := odata.Query{}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
+
 	qualsColumnMap := []QualsColumn{
 		{"app_id", "string", "appId"},
 		{"display_name", "string", "displayName"},

--- a/azuread/table_azuread_conditional_access_policy.go
+++ b/azuread/table_azuread_conditional_access_policy.go
@@ -76,6 +76,15 @@ func listAdConditionalAccessPolicies(ctx context.Context, d *plugin.QueryData, _
 
 	input := odata.Query{}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
+	
 	qualsColumnMap := []QualsColumn{
 		{"display_name", "string", "displayName"},
 		{"state", "string", "state"},

--- a/azuread/table_azuread_conditional_access_policy.go
+++ b/azuread/table_azuread_conditional_access_policy.go
@@ -74,10 +74,7 @@ func listAdConditionalAccessPolicies(ctx context.Context, d *plugin.QueryData, _
 	client := msgraph.NewConditionalAccessPolicyClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
+	input := odata.Query{}
 
 	qualsColumnMap := []QualsColumn{
 		{"display_name", "string", "displayName"},
@@ -87,13 +84,6 @@ func listAdConditionalAccessPolicies(ctx context.Context, d *plugin.QueryData, _
 	filter := buildCommaonQueryFilter(qualsColumnMap, d.Quals)
 	if len(filter) > 0 {
 		input.Filter = strings.Join(filter, " and ")
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
 	}
 
 	conditionalAccessPolicies, _, err := client.List(ctx, input)

--- a/azuread/table_azuread_domain.go
+++ b/azuread/table_azuread_domain.go
@@ -60,6 +60,15 @@ func listAdDomains(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 
 	input := odata.Query{}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
+
 	domains, _, err := client.List(ctx, input)
 	if err != nil {
 		if isNotFoundError(err) {

--- a/azuread/table_azuread_domain.go
+++ b/azuread/table_azuread_domain.go
@@ -58,17 +58,7 @@ func listAdDomains(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	client := msgraph.NewDomainsClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
-	}
+	input := odata.Query{}
 
 	domains, _, err := client.List(ctx, input)
 	if err != nil {

--- a/azuread/table_azuread_group.go
+++ b/azuread/table_azuread_group.go
@@ -19,8 +19,8 @@ func tableAzureAdGroup() *plugin.Table {
 		Name:        "azuread_group",
 		Description: "Represents an Azure Active Directory (Azure AD) group, which can be a Microsoft 365 group, or a security group.",
 		Get: &plugin.GetConfig{
-			Hydrate:           getAdGroup,
-			KeyColumns:        plugin.SingleColumn("id"),
+			Hydrate:    getAdGroup,
+			KeyColumns: plugin.SingleColumn("id"),
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listAdGroups,
@@ -96,6 +96,15 @@ func listAdGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	client.BaseClient.Authorizer = session.Authorizer
 
 	input := odata.Query{}
+
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
 
 	equalQuals := d.KeyColumnQuals
 	quals := d.Quals

--- a/azuread/table_azuread_group.go
+++ b/azuread/table_azuread_group.go
@@ -95,17 +95,7 @@ func listAdGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	client := msgraph.NewGroupsClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
-	}
+	input := odata.Query{}
 
 	equalQuals := d.KeyColumnQuals
 	quals := d.Quals

--- a/azuread/table_azuread_service_principal.go
+++ b/azuread/table_azuread_service_principal.go
@@ -80,10 +80,7 @@ func listAdServicePrincipals(ctx context.Context, d *plugin.QueryData, _ *plugin
 	client := msgraph.NewServicePrincipalsClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
+	input := odata.Query{}
 
 	qualsColumnMap := []QualsColumn{
 		{"display_name", "string", "displayName"},
@@ -94,13 +91,6 @@ func listAdServicePrincipals(ctx context.Context, d *plugin.QueryData, _ *plugin
 	filter := buildCommaonQueryFilter(qualsColumnMap, d.Quals)
 	if len(filter) > 0 {
 		input.Filter = strings.Join(filter, " and ")
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
 	}
 
 	servicePrincipals, _, err := client.List(ctx, input)

--- a/azuread/table_azuread_service_principal.go
+++ b/azuread/table_azuread_service_principal.go
@@ -82,6 +82,15 @@ func listAdServicePrincipals(ctx context.Context, d *plugin.QueryData, _ *plugin
 
 	input := odata.Query{}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
+
 	qualsColumnMap := []QualsColumn{
 		{"display_name", "string", "displayName"},
 		{"account_enabled", "bool", "accountEnabled"},

--- a/azuread/table_azuread_sign_in_report.go
+++ b/azuread/table_azuread_sign_in_report.go
@@ -74,6 +74,15 @@ func listAdSigninReports(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 
 	input := odata.Query{}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
+
 	signInReports, _, err := client.List(ctx, input)
 	if err != nil {
 		if isNotFoundError(err) {

--- a/azuread/table_azuread_sign_in_report.go
+++ b/azuread/table_azuread_sign_in_report.go
@@ -72,17 +72,7 @@ func listAdSigninReports(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	client := msgraph.NewSignInLogsClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
-	}
+	input := odata.Query{}
 
 	signInReports, _, err := client.List(ctx, input)
 	if err != nil {

--- a/azuread/table_azuread_user.go
+++ b/azuread/table_azuread_user.go
@@ -88,17 +88,7 @@ func listAdUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	client := msgraph.NewUsersClient(session.TenantID)
 	client.BaseClient.Authorizer = session.Authorizer
 
-	// As per our test result we have set the max limit to 999
-	input := odata.Query{
-		Top: 999,
-	}
-
-	limit := d.QueryContext.Limit
-	if limit != nil {
-		if *limit < 999 {
-			input.Top = int(*limit)
-		}
-	}
+	input := odata.Query{}
 
 	if helpers.StringSliceContains(d.QueryContext.Columns, "member_of") {
 		input.Expand = odata.Expand{

--- a/azuread/table_azuread_user.go
+++ b/azuread/table_azuread_user.go
@@ -89,6 +89,15 @@ func listAdUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	client.BaseClient.Authorizer = session.Authorizer
 
 	input := odata.Query{}
+	
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit > 0 && *limit <= 999 {
+			input.Top = int(*limit)
+		}
+	}
 
 	if helpers.StringSliceContains(d.QueryContext.Columns, "member_of") {
 		input.Expand = odata.Expand{


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select display_name, created_date_time from azuread_application;
+----------------------------------------------------------------------------------+---------------------------+
| display_name                                                                     | created_date_time         |
+----------------------------------------------------------------------------------+---------------------------+
| turbottest58147                                                                  | 2021-01-08T20:40:34+05:30 |
| testSubhajitSP-20200124131852                                                    | 2020-01-24T13:18:55+05:30 |
| Turbot Dev ReadOnly                                                              | 2019-07-30T14:20:14+05:30 |
| rup-testSP-20190822194017                                                        | 2019-08-22T19:40:17+05:30 |
| test-clusterSP-20190822160005                                                    | 2019-08-22T16:00:06+05:30 |
| testtagsSP-20200224115309                                                        | 2020-02-24T11:53:13+05:30 |
| a6336bb8-0450-488f-9de5-15b45f368a48                                             | 2020-05-07T15:19:23+05:30 |
| Turbot Registration                                                              | 2020-10-06T09:16:51+05:30 |
| TestImportDev                                                                    | 2020-05-29T15:33:27+05:30 |
| testSubhajitClusterSP-20200122152207                                             | 2020-01-22T15:22:10+05:30 |
| a6336bb8-0450-488f-9de5-15b45f368a48                                             | 2020-05-07T14:03:39+05:30 |
| mebautomationaccount_1bj5XsQE67Wrj79BDVmn+yH4W69GJD52bnKt6zZ4Jxk=                | 2020-02-02T09:16:19+05:30 |
| testcisv85SP-20191017180417                                                      | 2019-10-17T18:04:19+05:30 |
| testStacyIntgSP-20200330124311                                                   | 2020-03-30T12:43:16+05:30 |
| sd-test-import                                                                   | 2021-07-26T19:21:16+05:30 |
| Turbot Dev Reader                                                                | 2020-05-15T16:43:42+05:30 |
| Turbot Prod SaaS - bob-azure-sub                                                 | 2020-06-30T12:49:00+05:30 |
| a6336bb8-0450-488f-9de5-15b45f368a48                                             | 2020-05-06T17:04:41+05:30 |
| luisk8sSP-20200309185025                                                         | 2020-03-10T03:20:28+05:30 |
| Turbot Staging                                                                   | 2020-03-18T01:15:22+05:30 |
| azure-cli-2020-06-23-14-09-55                                                    | 2020-06-23T19:39:57+05:30 |
| Azure AD SAML Integration                                                        | 2020-07-02T12:31:46+05:30 |
| testSubhajitSP-20200116153655                                                    | 2020-01-16T15:36:57+05:30 |
| azure-cli-2020-06-23-11-52-09                                                    | 2020-06-23T17:22:11+05:30 |
| site-reco-svh-asr-automationaccount_ROT2NiJvXlzfPe6BVm3oEWckqHh3zmlnXn/aJQwHg8Y= | 2021-07-30T14:24:26+05:30 |
| turbottest76198                                                                  | 2020-11-02T23:46:19+05:30 |
| TestClusterSubhajitSP-20200122124704                                             | 2020-01-22T12:47:06+05:30 |
| alpha-clusterSP-20190826182004                                                   | 2019-08-26T18:20:06+05:30 |

```

```
> select display_name, created_date_time from azuread_application where display_name = 'Turbot Expediters';
+-------------------+---------------------------+
| display_name      | created_date_time         |
+-------------------+---------------------------+
| Turbot Expediters | 2020-04-20T20:47:30+05:30 |
+-------------------+---------------------------+
```

```
> select count(*) from azuread_sign_in_report;
+-------+
| count |
+-------+
| 3415  |
+-------+
```
</details>
