### PR TITLE
Update plugin to disable caching the creds

### DIFF
--- a/azuread/service.go
+++ b/azuread/service.go
@@ -30,11 +30,15 @@ GetGraphClient creates a graph service client configured from (~/.steampipe/conf
 func GetGraphClient(ctx context.Context, d *plugin.QueryData) (*msgraphsdkgo.GraphServiceClient, *msgraphsdkgo.GraphRequestAdapter, error) {
 	logger := plugin.Logger(ctx)
 
+	// Disable caching since it only saves ~.25ms and results in an SDK error
+	// when running consecutive queries for the sign_in_report and service_principal
+	// tables:
+	// Error: rpc error: code = Internal desc = hydrate function listAdSignInReports failed with panic runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)
 	// Have we already created and cached the session?
-	sessionCacheKey := "GetGraphClient"
-	if cachedData, ok := d.ConnectionManager.Cache.Get(sessionCacheKey); ok {
-		return cachedData.(*msgraphsdkgo.GraphServiceClient), nil, nil
-	}
+	// sessionCacheKey := "GetGraphClient"
+	// if cachedData, ok := d.ConnectionManager.Cache.Get(sessionCacheKey); ok {
+	// 	return cachedData.(*msgraphsdkgo.GraphServiceClient), nil, nil
+	// }
 
 	var tenantID, environment, clientID, clientSecret, certificatePath, certificatePassword string
 
@@ -172,8 +176,9 @@ func GetGraphClient(ctx context.Context, d *plugin.QueryData) (*msgraphsdkgo.Gra
 	}
 	client := msgraphsdkgo.NewGraphServiceClient(adapter)
 
+	// See comment above as to why caching is disabled
 	// Save session into cache
-	d.ConnectionManager.Cache.Set(sessionCacheKey, client)
+	// d.ConnectionManager.Cache.Set(sessionCacheKey, client)
 
 	return client, adapter, nil
 }


### PR DESCRIPTION
Disabling the caching since it only saves ~.25ms and results in an SDK error, when running consecutive queries for the `sign_in_report` and `service_principal` tables.
```
Error: rpc error: code = Internal desc = hydrate function listAdSignInReports failed with panic runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)
```