### PR TITLE
Add timeout parameter to golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@main
+    with:
+      timeout: 40m


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>

This PR adds a `timeout` parameter of `40m` to `golangci-lint` workflow to override the default value of `10m`.