### PR TITLE
Fixed adding 'Order by' or 'Group by' keywords to query results with Error Closes #109

### DIFF
--- a/azuread/table_azuread_directory_audit_report.go
+++ b/azuread/table_azuread_directory_audit_report.go
@@ -148,11 +148,10 @@ func listAdDirectoryAuditReports(ctx context.Context, d *plugin.QueryData, _ *pl
 	}
 
 	err = pageIterator.Iterate(ctx, func(pageItem interface{}) bool {
-
 		if directoryAudit, ok := pageItem.(models.DirectoryAuditable); ok {
 			d.StreamListItem(ctx, &ADDirectoryAuditReportInfo{directoryAudit})
-
 		}
+		
 			// Context can be cancelled due to manual cancellation or the limit has been hit
 			return d.RowsRemaining(ctx) != 0
 	})

--- a/azuread/table_azuread_directory_audit_report.go
+++ b/azuread/table_azuread_directory_audit_report.go
@@ -148,12 +148,13 @@ func listAdDirectoryAuditReports(ctx context.Context, d *plugin.QueryData, _ *pl
 	}
 
 	err = pageIterator.Iterate(ctx, func(pageItem interface{}) bool {
+		// To prevent errors during type conversion caused by inconsistent API responses (especially with larger data sets), we may get the different type of response (models.SignInable), we need to include the following check.
 		if directoryAudit, ok := pageItem.(models.DirectoryAuditable); ok {
 			d.StreamListItem(ctx, &ADDirectoryAuditReportInfo{directoryAudit})
 		}
-		
-			// Context can be cancelled due to manual cancellation or the limit has been hit
-			return d.RowsRemaining(ctx) != 0
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		return d.RowsRemaining(ctx) != 0
 	})
 	if err != nil {
 		plugin.Logger(ctx).Error("listAdDirectoryAuditReports", "paging_error", err)

--- a/azuread/table_azuread_directory_audit_report.go
+++ b/azuread/table_azuread_directory_audit_report.go
@@ -148,12 +148,13 @@ func listAdDirectoryAuditReports(ctx context.Context, d *plugin.QueryData, _ *pl
 	}
 
 	err = pageIterator.Iterate(ctx, func(pageItem interface{}) bool {
-		directoryAudit := pageItem.(models.DirectoryAuditable)
 
-		d.StreamListItem(ctx, &ADDirectoryAuditReportInfo{directoryAudit})
+		if directoryAudit, ok := pageItem.(models.DirectoryAuditable); ok {
+			d.StreamListItem(ctx, &ADDirectoryAuditReportInfo{directoryAudit})
 
-		// Context can be cancelled due to manual cancellation or the limit has been hit
-		return d.RowsRemaining(ctx) != 0
+		}
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			return d.RowsRemaining(ctx) != 0
 	})
 	if err != nil {
 		plugin.Logger(ctx).Error("listAdDirectoryAuditReports", "paging_error", err)

--- a/azuread/table_azuread_sign_in_report.go
+++ b/azuread/table_azuread_sign_in_report.go
@@ -106,6 +106,7 @@ func listAdSignInReports(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	err = pageIterator.Iterate(ctx, func(pageItem interface{}) bool {
+		// To prevent errors during type conversion caused by inconsistent API responses (especially with larger data sets), we may get the different type of response (models.DirectoryAuditable), we need to include the following check.
 		if signIn, ok := pageItem.(models.SignInable); ok {
 			d.StreamListItem(ctx, &ADSignInReportInfo{signIn})
 		}

--- a/azuread/table_azuread_sign_in_report.go
+++ b/azuread/table_azuread_sign_in_report.go
@@ -106,9 +106,9 @@ func listAdSignInReports(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	err = pageIterator.Iterate(ctx, func(pageItem interface{}) bool {
-		signIn := pageItem.(models.SignInable)
-
-		d.StreamListItem(ctx, &ADSignInReportInfo{signIn})
+		if signIn, ok := pageItem.(models.SignInable); ok {
+			d.StreamListItem(ctx, &ADSignInReportInfo{signIn})
+		}
 
 		// Context can be cancelled due to manual cancellation or the limit has been hit
 		return d.RowsRemaining(ctx) != 0


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
