### PR TITLE
Fix azuread_group to populate resource_behavior_options and resource_provisioning_options columns with improved data type handling. Closes #188

### DIFF
--- a/azuread/table_azuread_group.go
+++ b/azuread/table_azuread_group.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iancoleman/strcase"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
-	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -429,13 +428,14 @@ func buildGroupBoolNEFilter(quals plugin.KeyColumnQualMap) []string {
 func formatResourceBehaviorOptions(ctx context.Context, group models.Groupable) []string {
 	var resourceBehaviorOptions []string
 	data := group.GetAdditionalData()["resourceBehaviorOptions"]
+
 	if data != nil {
-		parsedData := group.GetAdditionalData()["resourceBehaviorOptions"].([]*jsonserialization.JsonParseNode)
+		parsedData := group.GetAdditionalData()["resourceBehaviorOptions"].([]interface{})
 
 		for _, r := range parsedData {
-			val, err := r.GetStringValue()
-			if err != nil {
-				plugin.Logger(ctx).Error("failed to parse resourceBehaviorOptions: %v", err)
+			val, ok := r.(*string)
+			if !ok {
+				plugin.Logger(ctx).Error("failed to parse resourceBehaviorOptions: %v", r)
 				val = nil
 			}
 
@@ -450,13 +450,14 @@ func formatResourceBehaviorOptions(ctx context.Context, group models.Groupable) 
 func formatResourceProvisioningOptions(ctx context.Context, group models.Groupable) []string {
 	var resourceProvisioningOptions []string
 	data := group.GetAdditionalData()["resourceProvisioningOptions"]
+
 	if data != nil {
-		parsedData := data.([]*jsonserialization.JsonParseNode)
+		parsedData := data.([]interface{})
 
 		for _, r := range parsedData {
-			val, err := r.GetStringValue()
-			if err != nil {
-				plugin.Logger(ctx).Error("failed to parse resourceProvisioningOptions: %v", err)
+			val, ok := r.(*string)
+			if !ok {
+				plugin.Logger(ctx).Error("failed to parse resourceProvisioningOptions: %v", r)
 				val = nil
 			}
 


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```

> select * from azuread_group
Warning: Server enforces maximum TTL of 300 seconds. Cannot set TTL to 900 seconds. TTL set to 300 seconds.
+--------------------------------------+------------------------+--------------------------------------+-------------------------------------------------------+--------+----------------+---------------------------+--------------------->
| tenant_id                            | display_name           | id                                   | description                                           | filter | classification | created_date_time         | expiration_date_time>
+--------------------------------------+------------------------+--------------------------------------+-------------------------------------------------------+--------+----------------+---------------------------+--------------------->
| ********-****-****-****-************ | test-graph             | 7bafb0a2-eee8-48c6-81ec-039836536d96 | test                                                  | <null> | <null>         | 2023-01-06T15:20:00+05:30 | <null>              >
| ********-****-****-****-************ | codytestgroup          | 58ad521d-56ed-4900-b23b-5c5532b270da | Testing O365 plugin                                   | <null> | <null>         | 2022-09-19T20:10:03+05:30 | <null>              >
| ********-****-****-****-************ | All Company            | 66e4618f-1eda-45d6-914c-6613a1ac2cfd | This is the default group for everyone in the network | <null> | <null>         | 2020-04-03T18:57:41+05:30 | <null>              >
| ********-****-****-****-************ | turbot                 | 293a8d51-3a6f-4073-b703-64175a9fc078 | turbot                                                | <null> | <null>         | 2020-04-03T18:39:23+05:30 | <null>              >
|                                      |                        |                                      |                                                       |        |                |                           |                     >
| ********-****-****-****-************ | CSE1                   | 24bb5c40-bc3b-4fb3-a84d-73d50a6fdcb2 | CSE1                                                  | <null> | <null>         | 2020-05-11T14:41:20+05:30 | <null>              >
| ********-****-****-****-************ | AAD DC Administrators  | 68060e6f-6fd1-470e-820e-5272aac5c13d | <null>                                                | <null> | <null>         | 2021-02-15T16:48:13+05:30 | <null>              >
| ********-****-****-****-************ | azure ad saml group    | 09a3de3c-2320-4d7b-9eea-ce4068b03020 | <null>                                                | <null> | <null>         | 2020-06-17T18:19:15+05:30 | <null>              >
| ********-****-****-****-************ | SAML Test1             | 82a47ab6-0690-4fb3-85a3-827c0ed8c315 | IntgTest1                                             | <null> | <null>         | 2020-07-02T15:49:34+05:30 | <null>              >
| ********-****-****-****-************ | test-delete            | 888bac45-85ef-4708-a90e-f7bde32bff93 | <null>                                                | <null> | <null>         | 2021-01-08T20:42:19+05:30 | <null>              >
| ********-****-****-****-************ | turbottest58147        | 8f1f3fb5-8f1f-4fe0-964b-2f98ff7997da | For testing tbt cli                                   | <null> | <null>         | 2021-01-08T20:40:06+05:30 | <null>              >
| ********-****-****-****-************ | TESTG3                 | 7cb1c402-4c60-41c6-b6fd-00fe4de69c8a | <null>                                                | <null> | <null>         | 2020-05-14T11:13:03+05:30 | <null>              >
| ********-****-****-****-************ | GRC SOC tier1          | 340aa4f9-fa98-47d1-8770-b88e3b307c3a | Lighthouse                                            | <null> | <null>         | 2024-06-03T22:00:11+05:30 | <null>              >
| ********-****-****-****-************ | CSE2                   | a00c2671-2723-4ab6-9e93-d51ee39e921b | <null>                                                | <null> | <null>         | 2020-05-21T19:47:58+05:30 | <null>              >
| ********-****-****-****-************ | TESTG2                 | 2b9583d6-eba6-4ef4-ac27-93886c6c0fa7 | <null>                                                | <null> | <null>         | 2020-05-14T11:04:53+05:30 | <null>              >
| ********-****-****-****-************ | fptestgrp              | ed4988b5-de0d-4afe-9f94-5b153ff44e38 | <null>                                                | <null> | <null>         | 2023-11-08T14:30:22+05:30 | <null>              >
| ********-****-****-****-************ | turbottest52896        | bb547511-3080-4684-a983-4e15230bf846 | For testing tbt cli                                   | <null> | <null>         | 2022-06-03T13:38:10+05:30 | <null>              >
| ********-****-****-****-************ | testcisv               | c5af2f17-866b-445a-aa17-44d8d015c9f1 | testing cisv 1                                        | <null> | <null>         | 2019-11-12T12:13:28+05:30 | <null>              >
| ********-****-****-****-************ | group-test             | 455254e2-a492-4a83-a5ca-90ec7505ce93 | <null>                                                | <null> | <null>         | 2023-04-10T21:28:45+05:30 | <null>              >
| ********-****-****-****-************ | Pipeling Scale Testing | a2dcab3a-8a67-42c9-9d92-2fe12e627e39 | Owners of Pipeling Scale Testing subscriptions        | <null> | <null>         | 2024-01-11T01:25:28+05:30 | <null>              >
| ********-****-****-****-************ | TESTG4                 | 7df39440-ac95-46f4-924f-3923d47ca602 | TESTG4                                                | <null> | <null>         | 2020-05-14T12:19:07+05:30 | <null>              >
| ********-****-****-****-************ | testinggg              | ee649be1-ccf4-462d-8e9f-3c7faf0d4d02 | test677                                               | <null> | <null>         | 2022-03-25T15:00:14+05:30 | <null>              >
| ********-****-****-****-************ | SAML test2             | fc2a80e0-8f1d-42a5-8f3e-3c7dd734fea8 | <null>                                                | <null> | <null>         | 2020-07-07T14:37:48+05:30 | <null>              >
| ********-****-****-****-************ | TESTG5                 | 1c8d0180-9531-4f96-9361-cc61eb2eedfc | TESTG5                                                | <null> | <null>         | 2020-05-14T12:19:20+05:30 | <null>              >
+--------------------------------------+------------------------+--------------------------------------+-------------------------------------------------------+--------+----------------+---------------------------+--------------------->


> select display_name, resource_behavior_options, resource_provisioning_options from azuread_group
Warning: Server enforces maximum TTL of 300 seconds. Cannot set TTL to 900 seconds. TTL set to 300 seconds.
+------------------------+------------------------------------------------------------------------------------------+-------------------------------+
| display_name           | resource_behavior_options                                                                | resource_provisioning_options |
+------------------------+------------------------------------------------------------------------------------------+-------------------------------+
| test-delete            | <null>                                                                                   | <null>                        |
| AAD DC Administrators  | <null>                                                                                   | <null>                        |
| group-test             | <null>                                                                                   | <null>                        |
| turbot                 | ["HideGroupInOutlook","SubscribeMembersToCalendarEventsDisabled","WelcomeEmailDisabled"] | ["Team"]                      |
| SAML Test1             | <null>                                                                                   | <null>                        |
| test-graph             | <null>                                                                                   | <null>                        |
| SAML test2             | <null>                                                                                   | <null>                        |
| CSE2                   | <null>                                                                                   | <null>                        |
| Pipeling Scale Testing | <null>                                                                                   | <null>                        |
| CSE1                   | <null>                                                                                   | <null>                        |
| testcisv               | <null>                                                                                   | <null>                        |
| TESTG2                 | <null>                                                                                   | <null>                        |
| All Company            | ["CalendarMemberReadOnly"]                                                               | <null>                        |
| azure ad saml group    | <null>                                                                                   | <null>                        |
| GRC SOC tier1          | <null>                                                                                   | <null>                        |
| turbottest52896        | <null>                                                                                   | <null>                        |
| TESTG4                 | <null>                                                                                   | <null>                        |
| testinggg              | <null>                                                                                   | <null>                        |
| codytestgroup          | <null>                                                                                   | <null>                        |
| TESTG3                 | <null>                                                                                   | <null>                        |
| TESTG5                 | <null>                                                                                   | <null>                        |
| fptestgrp              | <null>                                                                                   | <null>                        |
| turbottest58147        | <null>                                                                                   | <null>                        |
+------------------------+------------------------------------------------------------------------------------------+-------------------------------+


```
</details>
