### PR TITLE
add missing field to authorization_policy table

### DIFF
--- a/azuread/transforms.go
+++ b/azuread/transforms.go
@@ -345,7 +345,6 @@ func (authorizationPolicy *ADAuthorizationPolicyInfo) AuthorizationPolicyDefault
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToReadOtherUsers() != nil {
 		data["allowedToReadOtherUsers"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToReadOtherUsers()
 	}
-
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetPermissionGrantPoliciesAssigned() != nil {
 		data["permissionGrantPoliciesAssigned"] = authorizationPolicy.GetDefaultUserRolePermissions().GetPermissionGrantPoliciesAssigned()
 	}

--- a/azuread/transforms.go
+++ b/azuread/transforms.go
@@ -336,12 +336,16 @@ func (authorizationPolicy *ADAuthorizationPolicyInfo) AuthorizationPolicyDefault
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateApps() != nil {
 		data["allowedToCreateApps"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateApps()
 	}
+	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateTenants() != nil {
+		data["allowedToCreateTenants"] = authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateTenants()
+	}
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateSecurityGroups() != nil {
 		data["allowedToCreateSecurityGroups"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateSecurityGroups()
 	}
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToReadOtherUsers() != nil {
 		data["allowedToReadOtherUsers"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToReadOtherUsers()
 	}
+
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetPermissionGrantPoliciesAssigned() != nil {
 		data["permissionGrantPoliciesAssigned"] = authorizationPolicy.GetDefaultUserRolePermissions().GetPermissionGrantPoliciesAssigned()
 	}

--- a/azuread/transforms.go
+++ b/azuread/transforms.go
@@ -337,7 +337,7 @@ func (authorizationPolicy *ADAuthorizationPolicyInfo) AuthorizationPolicyDefault
 		data["allowedToCreateApps"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateApps()
 	}
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateTenants() != nil {
-		data["allowedToCreateTenants"] = authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateTenants()
+		data["allowedToCreateTenants"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateTenants()
 	}
 	if authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateSecurityGroups() != nil {
 		data["allowedToCreateSecurityGroups"] = *authorizationPolicy.GetDefaultUserRolePermissions().GetAllowedToCreateSecurityGroups()

--- a/docs/tables/azuread_authorization_policy.md
+++ b/docs/tables/azuread_authorization_policy.md
@@ -108,3 +108,31 @@ from
 where
   not allowed_email_verified_users_to_join_organization;
 ```
+
+
+### Check if Non-admin users can create tenants
+To enhance security practices, it is highly recommended to disable
+the feature that allows non-admin users to create Azure AD tenants.
+
+
+```sql+postgres
+select
+  id,
+	display_name,
+	default_user_role_permissions
+from
+	azuread_authorization_policy
+where
+	(default_user_role_permissions ->> 'allowedToCreateTenants')::boolean = True;
+```
+
+```sql+sqlite
+select
+  id,
+	display_name,
+	default_user_role_permissions
+from
+	azuread_authorization_policy
+where
+  json_extract(default_user_role_permissions, '$.allowedToCreateTenants')::boolean = True;
+```

--- a/docs/tables/azuread_authorization_policy.md
+++ b/docs/tables/azuread_authorization_policy.md
@@ -111,15 +111,13 @@ where
 
 
 ### Check if Non-admin users can create tenants
-To enhance security practices, it is highly recommended to disable
-the feature that allows non-admin users to create Azure AD tenants.
-
+To enhance security practices, it is highly recommended to disable the feature that allows non-admin users to create Azure AD tenants.
 
 ```sql+postgres
 select
   id,
-	display_name,
-	default_user_role_permissions
+  display_name,
+  default_user_role_permissions
 from
 	azuread_authorization_policy
 where
@@ -129,8 +127,8 @@ where
 ```sql+sqlite
 select
   id,
-	display_name,
-	default_user_role_permissions
+  display_name,
+  default_user_role_permissions
 from
 	azuread_authorization_policy
 where


### PR DESCRIPTION
Fixes #242 

For later reference.


```
steampipe query --output json "select id, display_name, default_user_role_permissions from azuread_authorization_policy"        
```

```
{
 "columns": [
  {
   "name": "id",
   "data_type": "text"
  },
  {
   "name": "display_name",
   "data_type": "text"
  },
  {
   "name": "default_user_role_permissions",
   "data_type": "jsonb"
  }
 ],
 "rows": [
  {
   "default_user_role_permissions": {
    "allowedToCreateApps": false,
    "allowedToCreateSecurityGroups": false,
    "allowedToCreateTenants": true,
    "allowedToReadOtherUsers": true,
    "permissionGrantPoliciesAssigned": [
     "ManagePermissionGrantsForOwnedResource.microsoft-dynamically-managed-permissions-for-chat",
     "ManagePermissionGrantsForOwnedResource.microsoft-dynamically-managed-permissions-for-team"
    ]
   },
   "display_name": "Authorization Policy",
   "id": "authorizationPolicy"
  }
 ]
}
```
